### PR TITLE
Add SimpleEconomy transistor integration

### DIFF
--- a/src/economizer/Economizer.php
+++ b/src/economizer/Economizer.php
@@ -25,6 +25,7 @@ use economizer\transistor\EconomyAPI;
 use economizer\transistor\PocketMoney;
 use economizer\transistor\MassiveEconomy;
 use economizer\transistor\EssentialsPE;
+use economizer\transistor\SimpleEconomy;
 
 class Economizer {
 
@@ -32,6 +33,7 @@ class Economizer {
 	const POCKET_MONEY		= "PocketMoney";
 	const MASSIVE_ECONOMY 		= "MassiveEconomy";
 	const ESSENTIALSPE		= "EssentialsPE";
+	const SIMPLE_ECONOMY		= "SimpleEconomy";
 	const DEFAULT_API		= self::ECONOMY_API;
 	
 	/** @var Economizer */
@@ -48,7 +50,8 @@ class Economizer {
 		self::ECONOMY_API		=> EconomyAPI::class,
 		self::POCKET_MONEY 		=> PocketMoney::class,
 		self::MASSIVE_ECONOMY 		=> MassiveEconomy::class,
-		self::ESSENTIALSPE		=> EssentialsPE::class
+		self::ESSENTIALSPE		=> EssentialsPE::class,
+		self::SIMPLE_ECONOMY		=> SimpleEconomy::class
 	];
 
 	public function __construct(Plugin $plugin, Transistor $transistor = null) {

--- a/src/economizer/transistor/SimpleEconomy.php
+++ b/src/economizer/transistor/SimpleEconomy.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace economizer\transistor;
+
+use NhanAZ\SimpleEconomy\Main as SimpleEconomyPlugin;
+use pocketmine\player\Player;
+use pocketmine\plugin\Plugin;
+use economizer\Transistor;
+
+class SimpleEconomy extends Transistor {
+
+	public function __construct(Plugin $api) {
+		parent::__construct($api);
+	}
+
+	/**
+	 * Get player money
+	 * @param Player|string $player
+	 * @return int|float
+	 */
+	public function balance($player) {
+		$name = $player instanceof Player ? $player->getName() : $player;
+		$plugin = SimpleEconomyPlugin::getInstance();
+		if ($plugin === null) return 0;
+		return $plugin->getMoney($name) ?? 0;
+	}
+
+	/**
+	 * Set player money.
+	 * @param Player|string $player
+	 * @param int|float $money
+	 * @param array $params = []
+	 */
+	public function setMoney($player, $money, array $params = []) {
+		$name = $player instanceof Player ? $player->getName() : $player;
+		$plugin = SimpleEconomyPlugin::getInstance();
+		if ($plugin === null) return false;
+		return $plugin->setMoney($name, (int) $money);
+	}
+
+	/**
+	 * Add money to player current balance.
+	 * @param Player|string $player
+	 * @param int|float $money
+	 * @param array $params = []
+	 */
+	public function addMoney($player, $money, array $params = []) {
+		$name = $player instanceof Player ? $player->getName() : $player;
+		$plugin = SimpleEconomyPlugin::getInstance();
+		if ($plugin === null) return false;
+		return $plugin->addMoney($name, (int) $money);
+	}
+
+	/**
+	 * Take player money.
+	 * @param Player|string $player
+	 * @param int|float $money
+	 * @param array $params = []
+	 */
+	public function takeMoney($player, $money, array $params = []) {
+		$name = $player instanceof Player ? $player->getName() : $player;
+		$plugin = SimpleEconomyPlugin::getInstance();
+		if ($plugin === null) return false;
+		return $plugin->reduceMoney($name, (int) $money);
+	}
+
+	public function ready() : bool {
+		$plugin = SimpleEconomyPlugin::getInstance();
+		return $plugin !== null && $this->getAPI()->isEnabled();
+	}
+
+	public function getMoneyUnit() {
+		$plugin = SimpleEconomyPlugin::getInstance();
+		if ($plugin === null) return "$";
+		return $plugin->getFormatter()->getSymbol();
+	}
+}


### PR DESCRIPTION
Register and implement a SimpleEconomy transistor adapter. Added src/economizer/transistor/SimpleEconomy.php which integrates with NhanAZ\SimpleEconomy, providing balance, setMoney, addMoney, takeMoney, ready, and getMoneyUnit methods (uses SimpleEconomyPlugin::getInstance()). Updated src/economizer/Economizer.php to import SimpleEconomy, add a SIMPLE_ECONOMY constant and include the adapter in the API map so the plugin can use SimpleEconomy as an economy provider. Returns sensible defaults when the economy plugin is unavailable.